### PR TITLE
Add rsync port (873) to bastion hosts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,3 +56,4 @@
     state: present
   with_items:
     - 22
+    - 873

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,7 @@
   with_items:
     - 80
     - 443
+    - 873
 
 - name: Bastion external access security group
   os_security_group:
@@ -56,4 +57,3 @@
     state: present
   with_items:
     - 22
-    - 873


### PR DESCRIPTION
In order to permit access to the rsync server running on OMERO
from all proxy hosts, port 873 needs to be opened for TCP.