### PR TITLE
Open 14060-14079 on idr-omero-external

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,16 @@
     - 4063
     - 4064
 
+- name: OMERO external load balanced security group rules
+  os_security_group_rule:
+    direction: ingress
+    port_range_max: 14079
+    port_range_min: 14060
+    protocol: tcp
+    remote_ip_prefix: 0.0.0.0/0
+    security_group: idr-omero-external
+    state: present
+
 - name: Web external access security group
   os_security_group:
     description: External access to web servers (managed by Ansible)


### PR DESCRIPTION
Opens port range 14060-14079 for future use with load-balancing

Tag: `1.2.0`