### PR TITLE
Define extra security group for NFS access

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Source IP addresses for the NFS security group
+idr_security_nfs_ip: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,4 +84,4 @@
   with_items:
     - "tcp"
     - "udp"
-  when: idr_security_nfs_ip != ""
+  when: idr_security_nfs_ip | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -67,3 +67,21 @@
     state: present
   with_items:
     - 22
+
+- name: NFS internal access security group
+  os_security_group:
+    description: Internal access to NFS servers (managed by Ansible)
+    name: idr-nfs-internal
+    state: present
+
+- name: NFS internal access security group rules
+  os_security_group_rule:
+    direction: ingress
+    protocol: "{{ item }}"
+    remote_ip_prefix: "{{ idr_security_nfs_ip }}"
+    security_group: idr-nfs-internal
+    state: present
+  with_items:
+    - "tcp"
+    - "udp"
+  when: idr_security_nfs_ip != ""


### PR DESCRIPTION
Create new OpenStack security allowing TCP/UDP ingress on the IP addresses of the NFS servers (configurable via private variables)