### PR TITLE
Remove port 873 from idr-web-external security group

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,6 +48,17 @@
   with_items:
     - 80
     - 443
+
+- name: Web external access security group rules
+  os_security_group_rule:
+    direction: ingress
+    port_range_max: "{{ item }}"
+    port_range_min: "{{ item }}"
+    protocol: tcp
+    remote_ip_prefix: 0.0.0.0/0
+    security_group: idr-web-external
+    state: absent
+  with_items:
     - 873
 
 - name: Bastion external access security group


### PR DESCRIPTION
Opening the rsync port 873 to untrusted networks (including the public networks) has been flagged by several CVEs as a potential source of MITM attack and other exploits.

Breaking change: `2.0.0`